### PR TITLE
add missing link to remote parquet query docs

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -54,6 +54,7 @@ website:
                 - src/docs/mgnify-proteins-web.md
                 - src/docs/mgnify-proteins-sequence-search.md
                 - src/docs/mgnify-proteins-big-query.qmd
+                - src/docs/mgnify-proteins-parquet-queries.qmd
                 - src/docs/mgnify-proteins-contig-sequences.qmd
             - href: src/docs/faqs.md
             - href: src/docs/glossary.md


### PR DESCRIPTION
Forgot to add the link to the new doc describing how to do remote queries on the FTP parquet files in `_quarto.yml`